### PR TITLE
Expand error log area to fill all content

### DIFF
--- a/server/app/assets/stylesheets/layout/_exercises.scss
+++ b/server/app/assets/stylesheets/layout/_exercises.scss
@@ -230,7 +230,7 @@
         background: url("../images/icon_errored.svg") no-repeat;
     }
     .log {
-        max-height: 40px;
+        max-height: unset;
     }
 }
 


### PR DESCRIPTION
This change will make block with error log expand to fill whole message.
Thanks for your work!
<img width="1170" alt="screen shot 2018-02-04 at 02 55 40" src="https://user-images.githubusercontent.com/11915087/35772988-fc37b2c0-0956-11e8-80e1-1a4f2f284257.png">
<img width="1197" alt="screen shot 2018-02-04 at 02 55 53" src="https://user-images.githubusercontent.com/11915087/35772989-fc672ac8-0956-11e8-8d10-58085bbfd1df.png">
